### PR TITLE
feature/auth persist redux

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,9 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.1.0",
-        "react-router-dom": "^7.1.1"
+        "react-router-dom": "^7.1.1",
+        "redux-persist": "^6.0.0",
+        "redux-persist-expire": "^1.1.1"
       },
       "devDependencies": {
         "@testing-library/dom": "^9.3.4",
@@ -24,6 +26,7 @@
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
         "@types/react-router-dom": "^5.3.3",
+        "@types/redux-persist": "^4.3.1",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
@@ -1837,7 +1840,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
       "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3014,6 +3016,16 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "node_modules/@types/redux-persist": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/redux-persist/-/redux-persist-4.3.1.tgz",
+      "integrity": "sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==",
+      "deprecated": "This is a stub types definition for redux-persist (https://github.com/rt2zz/redux-persist). redux-persist provides its own type definitions, so you don't need @types/redux-persist installed!",
+      "dev": true,
+      "dependencies": {
+        "redux-persist": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -7344,6 +7356,31 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
+    "node_modules/redux-persist-expire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/redux-persist-expire/-/redux-persist-expire-1.1.1.tgz",
+      "integrity": "sha512-CoVGJrIHpg7H1++PFRivY61hC9weN1SsK80YV6axr7SxIcZzlYvnXitlxIbByFfKDTujInw40abEPIzW1Hbp/g==",
+      "dependencies": {
+        "redux": "^4.0.5",
+        "redux-persist": "^6.0.0"
+      }
+    },
+    "node_modules/redux-persist-expire/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -7395,8 +7432,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -10078,7 +10114,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
       "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
@@ -10818,6 +10853,15 @@
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "@types/redux-persist": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/redux-persist/-/redux-persist-4.3.1.tgz",
+      "integrity": "sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==",
+      "dev": true,
+      "requires": {
+        "redux-persist": "*"
       }
     },
     "@types/semver": {
@@ -13898,6 +13942,31 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
+    },
+    "redux-persist-expire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/redux-persist-expire/-/redux-persist-expire-1.1.1.tgz",
+      "integrity": "sha512-CoVGJrIHpg7H1++PFRivY61hC9weN1SsK80YV6axr7SxIcZzlYvnXitlxIbByFfKDTujInw40abEPIzW1Hbp/g==",
+      "requires": {
+        "redux": "^4.0.5",
+        "redux-persist": "^6.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+          "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
+      }
+    },
     "redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
@@ -13938,8 +14007,7 @@
     "regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regenerator-transform": {
       "version": "0.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.1.0",
-    "react-router-dom": "^7.1.1"
+    "react-router-dom": "^7.1.1",
+    "redux-persist": "^6.0.0",
+    "redux-persist-expire": "^1.1.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.3.4",
@@ -31,6 +33,7 @@
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
     "@types/react-router-dom": "^5.3.3",
+    "@types/redux-persist": "^4.3.1",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,17 @@
 import "./App.css"
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
-import { useAppSelector } from "./app/hooks"
+import { BrowserRouter, Routes, Route } from "react-router-dom"
 import Home from "./pages/Home"
 import Login from "./pages/Login"
-
-const PrivateRoute = ({ element }: { element: JSX.Element }) => {
-  const isAuthenticated = useAppSelector(state => state.auth.isAuthenticated)
-  return isAuthenticated ? element : <Navigate to="/" replace />
-}
+import NotFound from "./pages/NotFound"
+import PrivateRoute from "./components/PrivateRoute"
 
 const App = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<Login />} />
-        <Route path="/home" element={<PrivateRoute element={<Home />} />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/" element={<PrivateRoute element={<Home />} />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -13,7 +13,7 @@ function Navbar() {
     try {
       dispatch(logoutUser())
 
-      navigate("/")
+      navigate("/logout")
     } catch (error) {
       console.error("Logout failed:", error)
     }

--- a/frontend/src/components/PrivateRoute/index.tsx
+++ b/frontend/src/components/PrivateRoute/index.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from "react-router-dom"
+import { useAppSelector } from "../../app/hooks"
+
+const PrivateRoute = ({ element }: { element: JSX.Element }) => {
+  const isAuthenticated = useAppSelector(state => state.auth.isAuthenticated)
+  return isAuthenticated ? element : <Navigate to="/login" replace />
+}
+
+export default PrivateRoute;

--- a/frontend/src/constants/statusCodes.ts
+++ b/frontend/src/constants/statusCodes.ts
@@ -1,0 +1,1 @@
+export const UNAUTHORIZED = 401; 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,8 +2,9 @@ import React from "react"
 import { createRoot } from "react-dom/client"
 import { Provider } from "react-redux"
 import App from "./App"
-import { store } from "./app/store"
+import { persistor, store } from "./app/store"
 import "./index.css"
+import { PersistGate } from "redux-persist/integration/react"
 
 const container = document.getElementById("root")
 
@@ -13,6 +14,7 @@ if (container) {
   root.render(
     <React.StrictMode>
       <Provider store={store}>
+        <PersistGate loading={<div>Loading...</div>} persistor={persistor} />
         <App />
       </Provider>
     </React.StrictMode>,

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,6 +1,8 @@
 import type React from "react"
 import { useEffect, useState } from "react"
 import Navbar from "../../components/Navbar"
+import { useNavigate } from "react-router-dom"
+import { UNAUTHORIZED } from "../../constants/statusCodes"
 
 // Define types for the user data
 interface User {
@@ -10,6 +12,7 @@ interface User {
 }
 
 const Users: React.FC = () => {
+  const navigate = useNavigate()
   const [users, setUsers] = useState<User[]>([]) // Users state is an array of User objects
   const [error, setError] = useState<string | null>(null) // Error state can be a string or null
 
@@ -31,6 +34,9 @@ const Users: React.FC = () => {
           setUsers(data.users)
         } else {
           setError("Failed to fetch users")
+          if (response.status === UNAUTHORIZED) {
+            navigate("/login")
+          }
         }
       } catch (err) {
         setError(
@@ -46,7 +52,8 @@ const Users: React.FC = () => {
   return (
     <div>
       <Navbar />
-      <h1>User List</h1>
+      <h1>Home Page</h1>
+      <h2>User List</h2>
       {error && <p>{error}</p>}
       <ul>
         {users.length > 0 ? (

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -5,7 +5,6 @@ import { useAppDispatch } from "../../app/hooks"
 import { useAppSelector } from "../../app/hooks"
 import type { RootState } from "../../app/store"
 
-import Cookies from "js-cookie"
 import { loginAsync } from "../../features/auth/authSlice"
 
 export type LoginCredentials = {
@@ -36,7 +35,7 @@ function Login() {
 
     try {
       await dispatch(loginAsync(credentials)).unwrap()
-      navigate("/home")
+      navigate("/")
     } catch (err) {
       //   console.error("Login failed:", error)
       console.error("Login failed:", err)

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -1,0 +1,12 @@
+import type React from "react"
+
+const NotFound: React.FC = () => {
+  return (
+    <div>
+      <h1>404 - Page Not Found</h1>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  )
+}
+
+export default NotFound


### PR DESCRIPTION
- Add NotFound page, implement PrivateRoute, and improve authentication handling
- Add redux-persist-expire to persist state for 8 hours (matching JWT lifespan)

This PR introduces a 404 NotFound page for unmatched routes, a PrivateRoute component to protect authenticated routes, and improves authentication handling to manage user sessions more effectively. Additionally, we integrate the `redux-persist-expire` package to persist the Redux state for 8 hours, aligning with the JWT lifespan.

For more details on the `redux-persist-expire` package, refer to the [npm package documentation](https://www.npmjs.com/package/redux-persist-expire).
